### PR TITLE
Adde Legacy Swift Language Verwsion = NO to OSX Target

### DIFF
--- a/NSDateTimeAgo.xcodeproj/project.pbxproj
+++ b/NSDateTimeAgo.xcodeproj/project.pbxproj
@@ -302,6 +302,7 @@
 				PRODUCT_NAME = NSDateTimeAgo;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -324,6 +325,7 @@
 				PRODUCT_NAME = NSDateTimeAgo;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
It was not compiling with Carthage and OSX/Mac Target. This commit compiles without any issues